### PR TITLE
Clarify role of extensions in relation to spec

### DIFF
--- a/extensions/index.md
+++ b/extensions/index.md
@@ -11,6 +11,8 @@ layout: page
 ## {{ page.title }}
 Extensions are community developed contributions to the Open Badges Specification. Any issuer may define and publish them to include new types of metadata in badges. Any other issuer may use the same extensions to publish similar information in a mutually recognizable way.
 
+These extensions are not part of the core specification and are governed by licensing and copyright terms of the authoring individuals and organizations.
+
 ### Open Badges Community Extensions [(below)](#CommunityExtensions)
 Submit your published extensions to this page with a pull request on [GitHub](https://github.com/openbadges/openbadges-specification/blob/master/extensions/index.md), following the existing format of the page.
 
@@ -252,104 +254,15 @@ BadgeClass
 ### <a name="IssuerAccreditation"></a> Issuer Accreditation (DRAFT)
 _Author: [IMS Global](https://github.com/imsglobal)_
 
-This extension provides a reference to a single or to an array of multiple accreditation bodies as related to the Issuer Profile. Please note that this extension is in draft mode and may not be ready for production.
+Extension located at https://www.imsglobal.org/ims-badge-extensions-education
 
 
-<div class="table-wrapper">
-
-Property     | Type        | Value Description
--------------|-------------|---------
-**@context** | context IRI | [https://openbadgespec.org/extensions/issuerAccreditationExtension/context.json](./issuerAccreditationExtension/context.json)
-**type**     | type IRI array |`['Extension', 'extensions:IssuerAccreditation']`
-**name**     | string| The official name of the organization, e.g. the registered company name. (required)
-<a name="accreditationContactInstructions"></a>**contactInstructions**     | string | Contact instructions for an accrediting organization. (required)
-**url**     | string,uri | URL of the accrediting organization. (required)
-**address**     | object | Physical address of the accrediting organization. Object contains specific locality information. (required)
-**streetAddress**     | string | The street address. For example, 1600 Amphitheatre Pkwy.
-**addressLocality**     | string |  The locality. For example, Mountain View.
-**addressRegion**     | string |  The region. For example, CA.
-**postalCode**     | string |  The postal code. For example, 94043.
-**description**     | string |  The description of the accrediting organization.
-**logo**     | string,uri |  The logo for the accrediting organization.
-**parentOrganization**     | object | The larger organization that the accrediting organization is a branch of, if any.
-**areaServed**     | string |  The geographic area where accreditation services are targeted.
-<a name="accreditationDate"></a>**accreditationDate**     | string |  The date accreditation was valid (ex: 2009-07-31).
-<a name="accreditationEducationSector"></a>**educationSector**     | string |  Focus of accreditation (ex: K12, Postsecondary, CTE, Workforce, Adult Ed).
-
-</div>
-
-**Extendable Badge Objects:**
-Issuer
-
-**Example implementation (Single Accreditor):**
-{% highlight json %}
-{
-  "extensions:IssuerAccreditation": {
-    "@context":"https://openbadgespec.org/extensions/issuerAccreditationExtension/context.json",
-    "type": ["Extension", "extensions:IssuerAccreditation"],
-    "name": "Higher Learning Commission",
-    "contactInstructions": "Visit website to request an institutional status and requirements report",
-    "url": "http://hlcommission.org",
-    "address": {
-      "streetAddress": "230 South LaSalle Street, Suite 7-500",
-      "addressLocality": "Chicago",
-      "addressRegion": "IL",
-      "postalCode": "60604-1411"
-    },
-    "description": "The Higher Learning Commission accredits degree-granting post-secondary educational institutions in the North Central region of the United States.",
-    "logo": "http://www.cgscfoundation.org/wp-content/uploads/2016/01/hlc-logo.png",
-    "parentOrganization" : {
-      "name": "North Central Association of Colleges and Schools",
-      "url": "http://www.northcentralassociation.org/"
-    },
-    "areaServed": "HLC accredits degree-granting post-secondary educational institutions in the North Central region, which includes the following 19 states: Arizona, Arkansas, Colorado, Illinois, Indiana, Iowa, Kansa, Michigan, Minnesota, Missouri, Nebraska, New Mexico, North Dakota, Ohio, Oklahoma, South Dakota, West Virginia, Wisconsin, Wyoming",
-    "accreditationDate": "2009-07-31",
-    "educationalSector": "post-secondary"
-}
-{% endhighlight %}
-
-**Example implementation (Two Accreditors):**
-{% highlight json %}
-{
-  "extensions:IssuerAccreditation": [{
-    "@context":"https://openbadgespec.org/extensions/issuerAccreditationExtension/context.json",
-    "type": ["Extension", "extensions:IssuerAccreditation"],
-    "name": "Northwest Commission on Colleges and Universities",
-    "contactInstructions": "Call or email the Commission Office",
-    "url": "http://www.nwccu.org/index.htm",
-    "address": {
-      "streetAddress": "8060 165th Ave. NE, Suite 100",
-      "addressLocality": "Redmond",
-      "addressRegion": "WA",
-      "postalCode": "98052"
-    },
-    "description": "The Northwest Commission on Colleges and Universities (NWCCU) is an independent, non-profit membership organization recognized by the U.S. Department of Education as the regional authority on educational quality and institutional effectiveness of higher education institutions.",
-    "areaServed": "The US seven-state Northwest region of Alaska, Idaho, Montana, Nevada, Oregon, Utah, and Washington. US-AK, US-ID, US-MT, US-NV, US-OR, US-UT, US-WA",
-    "accreditationDate": "2010-09-01",
-    "educationalSector": "Postsecondary"
-  },
-  {
-    "@context":"https://openbadgespec.org/extensions/issuerAccreditation/context.json",
-    "type": ["Extension", "extensions:issuerAccreditation"],
-    "name": "Commission on Accreditation of Allied Health Education Programs",
-    "contactInstructions": "Contact Kathleen Megivern, Executive Director, megivern@caahep.org",
-    "url": "http://www.ncacasi.org",
-    "address": {
-      "streetAddress": "25400 US Highway 19 N, Suite 158",
-      "addressLocality": "Clearwater",
-      "addressRegion": "FL",
-      "postalCode": "33763"
-    },
-    "description": "CAAHEP is the largest programmatic accreditor in the health sciences field. In collaboration with its Committees on Accreditation, CAAHEP reviews and accredits over 2000 educational programs in twenty-eight (28) health science occupations.",
-    "accreditationDate": "2014-04-01",
-    "educationalSector": "postsecondary"
-}]
-{% endhighlight %}
 
 ### <a name="Assessment"></a> Assessment (DRAFT)
 _Author: [IMS Global](https://github.com/imsglobal)_
 
-This extension provides information about single or multiple assessments that would be completed by the recipient as part of the requirements for earning an OpenBadge. There could be multiple assessments of different types for each badge earned. Separate, independent evaluations of a single assessment could result in multiple assessment/evaluation records, all included in a single instance of the extension. Please note that this extension is in draft mode and may not be ready for production.
+Extension located at https://www.imsglobal.org/ims-badge-extensions-education
+
 
 
 <div class="table-wrapper">
@@ -384,56 +297,6 @@ Property     | Type        | Value Description
 **Extendable Badge Objects:**
 Badge Class
 
-**Example implementation (Single Assessment):**
-{% highlight json %}
-"extensions:Assessment": {
-  "@context":"https://openbadgespec.org/extensions/assessmentExtension/context.json",
-  "type": ["Extension", "extensions:assessment"],
-  "overallDescription": "The assessment included are a simulated clinical setting and an actual clinical setting.",
-  "assessment": [
-    {
-      "assessmentDescription": "The assessment presents a hypertension scenario with simulated lab results. It is administered to pathophysiology students in an undergraduate nursing program. Completing the assessment requires analytical writing describing and justifying the diagnoses and eliminating alternative diagnoses. See the Pathology of High Blood Pressure assignment and the hypertension scenario used for this assessment.",
-      "assessmentType": "Artifact",
-      "assessmentOutput": "Written responses to the questions posed in the hypertension scenario",
-      "hasGroupParticipation": false,
-      "hasGroupEvaluation": false,
-      "evaluationMethod": "No studies have been done on reliability or validity but the hypertension scenario is consistent with scenarios encountered in nursing clinical practice.",
-      "assessmentExample": "http://placeholderurl.com",
-      "scoringMethodExampleDescription": "Placeholder text",
-      "assessmentEvaluation": "http://placeholderurl.com"
-    }
-  ]
-}
-{% endhighlight %}
-
-**Example implementation (Two Assessments):**
-{% highlight json %}
-"extensions:Assessment": {
-  "@context":"https://openbadgespec.org/extensions/assessmentExtension/context.json",
-  "type": ["Extension", "extensions:assessment"],
-  "overallDescription": "The assessments included are a simulated clinical setting and an actual clinical setting.",
-  "assessment": [
-    {
-      "assessmentDescription": "The assessment presents a hypertension scenario with simulated lab results. It is administered to pathophysiology students in an undergraduate nursing program. Completing the assessment requires analytical writing describing and justifying the diagnoses and eliminating alternative diagnoses. See the Pathology of High Blood Pressure assignment and the hypertension scenario used for this assessment.",
-      "assessmentType": "Artifact",
-      "assessmentOutput": "Written responses to the questions posed in the hypertension scenario",
-      "hasGroupParticipation": false,
-      "hasGroupEvaluation": false,
-      "evaluationMethod": "No studies have been done on reliability or validity but the hypertension scenario is consistent with scenarios encountered in nursing clinical practice.",
-      "assessmentExample": "http://placeholderurl.com"
-    },
-    {
-      "assessmentDescription": "Requires following standard procedures in measuring vital signs in a clinic patient and explaining the  results of a standard lab analysis on the basis of deviations from the norm.",
-      "assessmentType": "Performance",
-      "assessmentOutput": "Clinical demonstration of interpreting blood pressure and lab results to patient without diagnoses, evaluated by clinical supervisor.",
-      "hasGroupParticipation": false,
-      "hasGroupEvaluation": true,
-      "evaluationMethod": "Clinical supervisor uses a checklist to verify that the clinical demonstration includes the key elements that need to be communicated to the patient.",
-      "scoringMethodExampleDescription": "Placeholder text"
-    }
-  ]
-}
-{% endhighlight %}
 
 
 # xAPI Integration


### PR DESCRIPTION
Added clarification statement and replaced IMS Assessment and Accreditation segment with URL to IMS site where the content will now be located.